### PR TITLE
Fix grammar error

### DIFF
--- a/pycones/locale/en/LC_MESSAGES/django.po
+++ b/pycones/locale/en/LC_MESSAGES/django.po
@@ -544,7 +544,7 @@ msgstr "About the event"
 
 #: pycones/templates/headers.html:26 pycones/templates/pages/home.html:29
 msgid "Oradores Plenarios"
-msgstr "Keynoters Speakers"
+msgstr "Keynoter Speakers"
 
 #: pycones/templates/headers.html:30
 msgid "Agenda"


### PR DESCRIPTION
'Keynoter' is an adjective here, so it should be singular.

I'm not modifying the URL is order not to break any existing links that could be pointing to this page. Maybe we could use a redirect?